### PR TITLE
Fix clEsperanto top_hat_box radius param names

### DIFF
--- a/reference_topHatBox.md
+++ b/reference_topHatBox.md
@@ -161,7 +161,7 @@ clEsperanto Python (experimental)
 </summary>
 <pre class="highlight">import pyclesperanto_prototype as cle
 
-cle.top_hat_box(input, destination, radiusX, radiusY, radiusZ)
+cle.top_hat_box(input, destination, radius_x, radius_y, radius_z)
 
 </pre>
 


### PR DESCRIPTION
If you copy paste the example code and use radiusX, radiusY, radiusZ (with values) it results in an error:
TypeError: got an unexpected keyword argument 'radiusX'
Changing to radius_x and so on, resolves the error.