### PR TITLE
Fix pyclEsperanto code (difference_of_gaussian)

### DIFF
--- a/reference_differenceOfGaussian2D.md
+++ b/reference_differenceOfGaussian2D.md
@@ -163,7 +163,7 @@ clEsperanto Python (experimental)
 </summary>
 <pre class="highlight">import pyclesperanto_prototype as cle
 
-cle.difference_of_gaussian(input, destination, sigma1x, sigma1y, sigma2x, sigma2y)
+cle.difference_of_gaussian(input, destination, sigma1_x, sigma1_y, sigma2_x, sigma2_y)
 
 </pre>
 


### PR DESCRIPTION
The function doesn't run if copy-pasted as is. Underscores (_) are required before the x and y.